### PR TITLE
update README with wiki/help info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-This is the development repo for AHA! badge designs.
+## Getting Started
+Please read this Wiki article on [Loading software over USB](https://github.com/AustinHackers/ahabadge/wiki/Loading-software-over-USB)] to get started with loading firmware or making changes to the badge.
+
+## Getting Help
+If you are in need of assistance please review the [Wiki](https://github.com/AustinHackers/ahabadge/wiki/Loading-software-over-USB) first, and then proceed with opening an [Issue](https://github.com/AustinHackers/ahabadge/issues).
+
+
+


### PR DESCRIPTION
Add links to the README for the existing wiki article on loading software to the badge as well as pointing to the Wiki and Issues pages.